### PR TITLE
session key of project plugins in config  and jinja filters added

### DIFF
--- a/module.py
+++ b/module.py
@@ -16,7 +16,7 @@
 from pylon.core.tools import log  # pylint: disable=E0611,E0401
 from pylon.core.tools import module  # pylint: disable=E0611,E0401
 # from pylon.core.tools.context import Context as Holder  # pylint: disable=E0611,E0401
-
+from .tools.jinja_filters import humanize_timestamp, format_datetime
 
 # from .db_manager import db_session
 
@@ -74,6 +74,10 @@ class Module(module.ModuleModel):
         self.descriptor.register_tool('shared', self)
 
         self.descriptor.init_api()
+
+        self.context.app.jinja_env.filters['humanize_timestamp'] = humanize_timestamp
+        self.context.app.jinja_env.filters['format_datetime'] = format_datetime
+
 
     #     self.context.app.teardown_appcontext(self.shutdown_session)
     #

--- a/tools/config.py
+++ b/tools/config.py
@@ -37,6 +37,7 @@ class Config(metaclass=SingletonABC):
 
     SECRET_KEY = os.environ.get("SECRET_KEY", ":iMHK_F`4hyrE;Wfr;+Ui8l&R3wYiB")
     PROJECT_CACHE_KEY = os.environ.get("PROJECT_CACHE_KEY", "project_cache_key")
+    PROJECT_CACHE_PLUGINS = os.environ.get("PROJECT_CACHE_PLUGINS", "project_cache_plugins")
     USER_CACHE_KEY = os.environ.get("USER_CACHE_KEY", "user_session")
     DEV = LOCAL_DEV
     RABBIT_HOST = RABBIT_HOST

--- a/tools/jinja_filters.py
+++ b/tools/jinja_filters.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+
+def humanize_timestamp(timestamp: str):
+    dt = datetime.fromtimestamp(int(timestamp)/1000.0)
+    return format_datetime(dt)
+
+
+def format_datetime(dt: datetime):
+    return dt.strftime("%d.%m.%Y, %H:%M:%S")


### PR DESCRIPTION
Changes:
1. Custom jinja filters added
2. PROJECT_CACHE_PLUGINS key in config added. It is used in storing project plugins in session using the key in config